### PR TITLE
Can specify a project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ jobs:
         uses: amoeba/standardrb-action@v2
 ```
 
+You can specify a project path if your application is not at the root of the
+repository:
+
+```
+- name: standardrb
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PROJECT_PATH: my_rails_app/
+  uses: amoeba/standardrb-action@v2
+```
+
 ## Contributing
 
 Please file an [Issue](https://github.com/amoeba/standardrb-action) for bug reports, feature requests, or other comments.

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -8,6 +8,7 @@ require 'time'
 @GITHUB_EVENT_PATH = ENV["GITHUB_EVENT_PATH"]
 @GITHUB_TOKEN = ENV["GITHUB_TOKEN"]
 @GITHUB_WORKSPACE = ENV["GITHUB_WORKSPACE"]
+@PROJECT_PATH = ENV["PROJECT_PATH"].nil? ? @GITHUB_WORKSPACE : "#{@GITHUB_WORKSPACE}/#{ENV["PROJECT_PATH"]}"
 
 @event = JSON.parse(File.read(ENV["GITHUB_EVENT_PATH"]))
 @repository = @event["repository"]
@@ -77,7 +78,7 @@ end
 def run_standardrb
   annotations = []
   errors = nil
-  Dir.chdir(@GITHUB_WORKSPACE) {
+  Dir.chdir(@PROJECT_PATH) {
     errors = JSON.parse(`standardrb --format json`)
   }
   conclusion = "success"


### PR DESCRIPTION
Some repository does not have their ruby/rails app at the root. This PR adds the ability to specify a path to run standardrb.
