### PR TITLE
Explicit Permissions for Dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ name: CI
 
 on: [push]
 
-permissions:
-  checks: write
-  contents: read
-
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -54,6 +50,20 @@ repository:
     PROJECT_PATH: my_rails_app/
   uses: amoeba/standardrb-action@v2
 ```
+
+## Common Issues
+
+### `create_check` Forbidden
+
+If a Dependabot-generated branch triggers this action, you might get an error that can be solve by setting the permissions in the yaml:
+
+```yaml
+permissions:
+  checks: write
+  contents: read
+```
+
+You can get more context in [this GitHub blog post](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ name: CI
 
 on: [push]
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hello @amoeba 👋 ,

First of all, thanks for the great action, I love the inline annotations in the PR diff 🙂 .

I was frustrated with Dependabots auto-PR getting red on the `StandardRB` action and I realized it was failing because of a permission issue. I [read the doc](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) and tried this minmal configuration:

```yaml
permissions:
  checks: write
  contents: read
```

I thought that would be useful to others so here's my PR.

Thanks!