### PR TITLE
Use 'standard' gem instead of old 'standardrb' wrapper

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-gem install standardrb
+gem install standard
 
 ruby /action/lib/index.rb


### PR DESCRIPTION
The `standardrb` gem is an older (but theoretically still supported?) wrapper for standard. There doesn't actually appear to be any reason to use this so it seems appropriate to switch to the "expected" gem. The executable is still called `standardrb` so no changes are required there.