### PR TITLE
Raise error when no files found to pass to standard

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -84,6 +84,8 @@ def run_standardrb
   conclusion = "success"
   count = 0
 
+  raise "No files found to pass to standard" if errors["files"].none?
+
   errors["files"].each do |file|
     path = file["path"]
     offenses = file["offenses"]


### PR DESCRIPTION
In setting up this action I had misconfigured things, and it took me a while to realize that my builds were "passing" not because they were free of errors, but standardrb was exiting successfully because it processed zero files. I think it's a fair assumption that something is wrong if no files are reported as checked by standardrb, so this just raises an error in that case rather than silently working.