### PR TITLE
Set Dockerfile base image to 'ruby:3.2'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:3.2
 
 LABEL com.github.actions.name="StandardRB"
 LABEL com.github.actions.description="Lint your Ruby code in parallel to your builds with StandardRB"


### PR DESCRIPTION
Switches the base image to Ruby 3.2 as there doesn't seem to be much reason to continue staying on 2.7, especially as it went EOL in March 2023.